### PR TITLE
Specifies mime type for file to download

### DIFF
--- a/MSBookmarklet.js
+++ b/MSBookmarklet.js
@@ -90,7 +90,7 @@ javascript: (function () {
 
         var allMediaPresenter = playerOpts.d.Presentation.Streams[1].VideoUrls;
         for (var i = 0; i < allMediaPresenter.length; i++) {
-          if (allMediaPresenter[i].MediaType == 'MP4') {
+          if (allMediaPresenter[i].MediaType == 'MP4' && allMediaPresenter[i].MimeType == 'video/mp4') {
             var presenterMp4Url = allMediaPresenter[i].Location;
           }
         }


### PR DESCRIPTION
There can be more than one VideoUrl with MediaType MP4. The one that makes the most sense to download is the one with MimeType of `video/mp4`, but there can also be one with `audio/mpegurl` which gives a (very small) `.m3u8` file.

This change just limits to the one MimeType